### PR TITLE
Use last_over_time to fix build_info query

### DIFF
--- a/dashboards/Autometrics Function Explorer.json
+++ b/dashboards/Autometrics Function Explorer.json
@@ -149,7 +149,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n) > 0",
+          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n) > 0",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -250,7 +250,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n)",
           "interval": "",
           "legendFormat": "",
           "range": true,

--- a/dashboards/Autometrics Overview.json
+++ b/dashboards/Autometrics Overview.json
@@ -175,7 +175,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\", \n      function=~\"${functions_top_request_rate}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n) > 0",
+          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\", \n      function=~\"${functions_top_request_rate}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n) > 0",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -278,7 +278,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        result=\"error\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        result=\"error\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n)",
           "interval": "",
           "legendFormat": "",
           "range": true,

--- a/dashboards/Autometrics Service-Level Objectives (SLOs).json
+++ b/dashboards/Autometrics Service-Level Objectives (SLOs).json
@@ -319,7 +319,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n) / (\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -583,7 +583,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  1 - (\n    sum by (function, module, version, commit) (\n      rate(\n        function_calls_duration_bucket{\n          objective_name=\"$latency_objective\", \n          le=\"$latency_objective_latency_threshold\"\n        }[$__rate_interval]\n      )\n      * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n    ) / (\n      sum by (function, module, version, commit) (\n        rate(\n          function_calls_duration_count{\n            objective_name=\"$latency_objective\"\n          }[$__rate_interval]\n        )\n        * on(instance, job) group_left(version, commit) (build_info or on (instance, job) up)\n      ) > 0\n    )\n  )\n) > 0",
+          "expr": "(\n  1 - (\n    sum by (function, module, version, commit) (\n      rate(\n        function_calls_duration_bucket{\n          objective_name=\"$latency_objective\", \n          le=\"$latency_objective_latency_threshold\"\n        }[$__rate_interval]\n      )\n      * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n    ) / (\n      sum by (function, module, version, commit) (\n        rate(\n          function_calls_duration_count{\n            objective_name=\"$latency_objective\"\n          }[$__rate_interval]\n        )\n        * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n      ) > 0\n    )\n  )\n) > 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
When the version switches, we observed a problem where Prometheus would keep the value of the old gauge in memory and return it for the query using the build_info metric. This is a problem with our group_left query because Prometheus would complain that there are multiple matching label sets (the old and new version info).

Adding the last_over_time function seems to solve this because it seems to get rid of the old gauge value as soon as it no longer appears in the scrape.

