### PR TITLE
Add latency chart to function explorer dashboard

### DIFF
--- a/dashboards/Autometrics Function Explorer.json
+++ b/dashboards/Autometrics Function Explorer.json
@@ -65,7 +65,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Calls per second is calculated as the average over a 5-minute window",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -149,7 +149,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n) > 0",
+          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[$__rate_interval]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n) > 0",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -176,7 +176,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Error Rate",
+            "axisLabel": "% of Function Calls That Errored",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -250,14 +250,113 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)\n  ) > 0\n)",
           "interval": "",
           "legendFormat": "",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Error Rate",
+      "title": "Error Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This shows the 99th and 95th percentile latency or response time for the given function.\n\nFor example, if the 99th percentile latency is 500 milliseconds, that means that 99% of calls to the function are handled within 500ms or less.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Function Call Duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "9.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(\n  histogram_quantile(0.99, \n    sum by (le, function, module, commit, version) (\n      rate(function_calls_duration_bucket{function=~\"$function\"}[$__rate_interval])\n      # Attach the `version` and `commit` labels from the `build_info` metric \n      * on (instance, job) group_left(version, commit) last_over_time(build_info[1s])\n    )\n  ),\n  # Add the label {percentile_latency=\"99\"} to the time series\n  \"percentile_latency\", \"99\", \"\", \"\"\n)\nor\nlabel_replace(\n  histogram_quantile(0.95, \n    sum by (le, function, module, commit, version) (\n      rate(function_calls_duration_bucket{function=~\"$function\"}[$__rate_interval])\n      # Attach the `version` and `commit` labels from the `build_info` metric \n      * on (instance, job) group_left(version, commit) last_over_time(build_info[1s])\n    )\n  ),\n  # Add the label {percentile_latency=\"95\"} to the time series\n  \"percentile_latency\", \"95\", \"\", \"\"\n)",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency (95th and 99th Percentile)",
       "type": "timeseries"
     }
   ],
@@ -305,6 +404,6 @@
   "timezone": "",
   "title": "Autometrics Function Explorer",
   "uid": "autometrics-function-explorer",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
Also switch charts to use `$__rate_interval` instead of `5m`

![image](https://user-images.githubusercontent.com/3262610/236155448-c9827608-ccb3-4fe6-a306-2aadaa37d108.png)
