### PR TITLE
Use build_info[$__rate_interval] and show metrics with zero values

### DIFF
--- a/dashboards/Autometrics Function Explorer.json
+++ b/dashboards/Autometrics Function Explorer.json
@@ -149,7 +149,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[$__rate_interval]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n) > 0",
+          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\",\n      function=~\"${function}\"\n    }[$__rate_interval]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -250,7 +250,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        result=\"error\", \n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  )) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\",\n        function=~\"${function}\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ))",
           "interval": "",
           "legendFormat": "",
           "range": true,

--- a/dashboards/Autometrics Overview.json
+++ b/dashboards/Autometrics Overview.json
@@ -175,7 +175,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\", \n      function=~\"${functions_top_request_rate}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n) > 0",
+          "expr": "sum by (function, module, version, commit) (\n  rate(\n    {\n      __name__=~\"function_calls_count(?:_total)?\", \n      function=~\"${functions_top_request_rate}\"\n    }[5m]\n  )\n  * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -278,7 +278,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        result=\"error\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) > 0\n) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        result=\"error\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  )) / (\n  sum by(function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        function=~\"${functions_top_error_rate}\"\n      }[5m]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ))",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -346,14 +346,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "query_result(topk($num_function_limit, sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\", result=\"error\"}[$__range])) / (sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\"}[$__range])) > 0)))\n",
+        "definition": "query_result(topk($num_function_limit, sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\", result=\"error\"}[$__range])) / (sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\"}[$__range])))))\n",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "functions_top_error_rate",
         "options": [],
         "query": {
-          "query": "query_result(topk($num_function_limit, sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\", result=\"error\"}[$__range])) / (sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\"}[$__range])) > 0)))\n",
+          "query": "query_result(topk($num_function_limit, sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\", result=\"error\"}[$__range])) / (sum by (function, module) (rate({__name__=~\"function_calls_count(?:_total)?\"}[$__range])))))\n",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/Autometrics Service-Level Objectives (SLOs).json
+++ b/dashboards/Autometrics Service-Level Objectives (SLOs).json
@@ -147,7 +147,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "1 - (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__range])\n    ) or on() vector(0)\n  ) / (\n    sum(\n      rate(\n        {\n          __name__=~\"function_calls_count(?:_total)?\", \n          objective_name=\"$success_rate_objective\"\n        }[$__range]\n      )\n    ) > 0\n  )",
+          "expr": "1 - (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__range])\n    ) or on() vector(0)\n  ) / (\n    sum(\n      rate(\n        {\n          __name__=~\"function_calls_count(?:_total)?\", \n          objective_name=\"$success_rate_objective\"\n        }[$__range]\n      )\n    )  )",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -224,7 +224,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "1 - (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__range]\n    )\n  ) > 0\n)",
+          "expr": "1 - (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__range]\n    )\n  ))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -320,7 +320,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) >= 0\n) / (\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) > 0\n)",
+          "expr": "(\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\", \n        result=\"error\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ) >= 0\n) / (\n  sum by (function, module, version, commit) (\n    rate(\n      {\n        __name__=~\"function_calls_count(?:_total)?\", \n        objective_name=\"$success_rate_objective\"\n      }[$__rate_interval]\n    )\n    * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n  ))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -410,7 +410,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(\n  sum(\n    rate(\n      function_calls_duration_bucket{\n        objective_name=\"$latency_objective\", \n        le=\"$latency_objective_latency_threshold\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      function_calls_duration_count{\n        objective_name=\"$latency_objective\"\n      }[$__range]\n    )\n  ) > 0\n)",
+          "expr": "(\n  sum(\n    rate(\n      function_calls_duration_bucket{\n        objective_name=\"$latency_objective\", \n        le=\"$latency_objective_latency_threshold\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      function_calls_duration_count{\n        objective_name=\"$latency_objective\"\n      }[$__range]\n    )\n  ))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -487,7 +487,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(\n  sum(\n    rate(\n      function_calls_duration_bucket{\n        objective_name=\"$latency_objective\", \n        le=\"$latency_objective_latency_threshold\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      function_calls_duration_count{\n        objective_name=\"$latency_objective\"\n      }[$__range]\n    )\n  ) > 0\n)",
+          "expr": "(\n  sum(\n    rate(\n      function_calls_duration_bucket{\n        objective_name=\"$latency_objective\", \n        le=\"$latency_objective_latency_threshold\"\n      }[$__range]\n    )\n  ) or on() vector(0)\n) / (\n  sum(\n    rate(\n      function_calls_duration_count{\n        objective_name=\"$latency_objective\"\n      }[$__range]\n    )\n  ))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -585,7 +585,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(\n  1 - (\n    sum by (function, module, version, commit) (\n      rate(\n        function_calls_duration_bucket{\n          objective_name=\"$latency_objective\", \n          le=\"$latency_objective_latency_threshold\"\n        }[$__rate_interval]\n      )\n      * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n    ) / (\n      sum by (function, module, version, commit) (\n        rate(\n          function_calls_duration_count{\n            objective_name=\"$latency_objective\"\n          }[$__rate_interval]\n        )\n        * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n      ) > 0\n    )\n  )\n) > 0",
+          "expr": "(\n  1 - (\n    sum by (function, module, version, commit) (\n      rate(\n        function_calls_duration_bucket{\n          objective_name=\"$latency_objective\", \n          le=\"$latency_objective_latency_threshold\"\n        }[$__rate_interval]\n      )\n      * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n    ) / (\n      sum by (function, module, version, commit) (\n        rate(\n          function_calls_duration_count{\n            objective_name=\"$latency_objective\"\n          }[$__rate_interval]\n        )\n        * on(instance, job) group_left(version, commit) (last_over_time(build_info[$__rate_interval]) or on (instance, job) up)\n      )    )\n  )\n)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
- Use $__rate_interval instead of 1s for build_info range
- Show metrics even when their value is zero
