### PR TITLE
Add guidance on objective names

### DIFF
--- a/specs/autometrics_v1.0.0.md
+++ b/specs/autometrics_v1.0.0.md
@@ -245,7 +245,9 @@ If a function has an [SLO](#service-level-objectives-slos) attached, this label
 MUST contain the user-specified name of the objective. If there is no SLO
 attached, this label MUST be absent or empty (`""`).
 
-The library SHOULD warn users against declaring objective names with certain special characters, such as `%`, `(`, and `)`.
+The library SHOULD warn users when an objective name contains characters other than alphanumeric characters, `_`, `-`, or a space.
+
+The library SHOULD warn users when an objective name does not start with an alphanumeric character.
 
 ### `objective.percentile`
 

--- a/specs/autometrics_v1.0.0.md
+++ b/specs/autometrics_v1.0.0.md
@@ -245,6 +245,8 @@ If a function has an [SLO](#service-level-objectives-slos) attached, this label
 MUST contain the user-specified name of the objective. If there is no SLO
 attached, this label MUST be absent or empty (`""`).
 
+The library SHOULD warn users against declaring objective names with certain special characters, such as `%`, `(`, and `)`.
+
 ### `objective.percentile`
 
 If a function has an [SLO](#service-level-objectives-slos) attached, this label

--- a/specs/autometrics_v1.0.0.md
+++ b/specs/autometrics_v1.0.0.md
@@ -345,3 +345,4 @@ initialization function to override this value as well.
   - Add `caller.module` label to `function.calls` metric
   - Rename `caller` label to `caller.function` in `function.calls` metric
 - Add `repository.url` and `repository.provider` labels to `build_info` metric
+- Add guidance on the `objective_name` label, and suggest to warn library users if they use anything other than alphanumeric characters, `_`, `-`, or a space


### PR DESCRIPTION
Small tweak to 1.0.0 spec that encourages library implementors to warn users against using percentages and parentheses in their SLO names